### PR TITLE
Convert into edge-triggered model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "ptyd"
 version = "0.1.0"
 dependencies = [
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -16,9 +16,9 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ name = "ptyd"
 version = "0.1.0"
 
 [dependencies]
-redox_syscall = "0.1"
+redox_syscall = "0.1.40"
 redox_termios = "0.1"

--- a/src/pgrp.rs
+++ b/src/pgrp.rs
@@ -45,7 +45,7 @@ impl Resource for PtyPgrp {
         }
     }
 
-    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+    fn read(&self, buf: &mut [u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let pty = pty_lock.borrow();
             let pgrp: &[u8] = unsafe {
@@ -60,13 +60,13 @@ impl Resource for PtyPgrp {
                 buf[i] = pgrp[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
-            Ok(0)
+            Ok(Some(0))
         }
     }
 
-    fn write(&self, buf: &[u8]) -> Result<usize> {
+    fn write(&self, buf: &[u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let mut pty = pty_lock.borrow_mut();
             let pgrp: &mut [u8] = unsafe {
@@ -81,7 +81,7 @@ impl Resource for PtyPgrp {
                 pgrp[i] = buf[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
             Err(Error::new(EPIPE))
         }
@@ -102,11 +102,14 @@ impl Resource for PtyPgrp {
         }
     }
 
-    fn fevent(&self) -> Result<()> {
+    fn fevent(&mut self) -> Result<()> {
         Err(Error::new(EBADF))
     }
 
-    fn fevent_count(&self) -> Option<usize> {
+    fn fevent_count(&mut self) -> Option<usize> {
         None
+    }
+    fn fevent_writable(&mut self) -> bool {
+        false
     }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -11,10 +11,11 @@ pub trait Resource {
     fn flags(&self) -> usize;
 
     fn path(&self, buf: &mut [u8]) -> Result<usize>;
-    fn read(&self, buf: &mut [u8]) -> Result<usize>;
-    fn write(&self, buf: &[u8]) -> Result<usize>;
+    fn read(&self, buf: &mut [u8]) -> Result<Option<usize>>;
+    fn write(&self, buf: &[u8]) -> Result<Option<usize>>;
     fn sync(&self) -> Result<usize>;
     fn fcntl(&mut self, cmd: usize, arg: usize) -> Result<usize>;
-    fn fevent(&self) -> Result<()>;
-    fn fevent_count(&self) -> Option<usize>;
+    fn fevent(&mut self) -> Result<()>;
+    fn fevent_count(&mut self) -> Option<usize>;
+    fn fevent_writable(&mut self) -> bool;
 }

--- a/src/termios.rs
+++ b/src/termios.rs
@@ -45,7 +45,7 @@ impl Resource for PtyTermios {
         }
     }
 
-    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+    fn read(&self, buf: &mut [u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let pty = pty_lock.borrow();
             let termios: &[u8] = pty.termios.deref();
@@ -55,13 +55,13 @@ impl Resource for PtyTermios {
                 buf[i] = termios[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
-            Ok(0)
+            Ok(Some(0))
         }
     }
 
-    fn write(&self, buf: &[u8]) -> Result<usize> {
+    fn write(&self, buf: &[u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let mut pty = pty_lock.borrow_mut();
             let termios: &mut [u8] = pty.termios.deref_mut();
@@ -71,7 +71,7 @@ impl Resource for PtyTermios {
                 termios[i] = buf[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
             Err(Error::new(EPIPE))
         }
@@ -92,11 +92,14 @@ impl Resource for PtyTermios {
         }
     }
 
-    fn fevent(&self) -> Result<()> {
+    fn fevent(&mut self) -> Result<()> {
         Err(Error::new(EBADF))
     }
 
-    fn fevent_count(&self) -> Option<usize> {
+    fn fevent_count(&mut self) -> Option<usize> {
         None
+    }
+    fn fevent_writable(&mut self) -> bool {
+        false
     }
 }

--- a/src/winsize.rs
+++ b/src/winsize.rs
@@ -45,7 +45,7 @@ impl Resource for PtyWinsize {
         }
     }
 
-    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+    fn read(&self, buf: &mut [u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let pty = pty_lock.borrow();
             let winsize: &[u8] = pty.winsize.deref();
@@ -55,13 +55,13 @@ impl Resource for PtyWinsize {
                 buf[i] = winsize[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
-            Ok(0)
+            Ok(Some(0))
         }
     }
 
-    fn write(&self, buf: &[u8]) -> Result<usize> {
+    fn write(&self, buf: &[u8]) -> Result<Option<usize>> {
         if let Some(pty_lock) = self.pty.upgrade() {
             let mut pty = pty_lock.borrow_mut();
             let winsize: &mut [u8] = pty.winsize.deref_mut();
@@ -71,7 +71,7 @@ impl Resource for PtyWinsize {
                 winsize[i] = buf[i];
                 i += 1;
             }
-            Ok(i)
+            Ok(Some(i))
         } else {
             Err(Error::new(EPIPE))
         }
@@ -92,11 +92,14 @@ impl Resource for PtyWinsize {
         }
     }
 
-    fn fevent(&self) -> Result<()> {
+    fn fevent(&mut self) -> Result<()> {
         Err(Error::new(EBADF))
     }
 
-    fn fevent_count(&self) -> Option<usize> {
+    fn fevent_count(&mut self) -> Option<usize> {
         None
+    }
+    fn fevent_writable(&mut self) -> bool {
+        false
     }
 }


### PR DESCRIPTION
This will allow pseudo-terminals to work cleanly with tokio.

Changes:
 - It now returns EAGAIN instead of Ok(0) on a failed nonblocking read.
 - It now sends write events when registered to notify that writing is always available.
 - It no longer sends events over and over.

**Warning: This BREAKS the following projects:**
 - userutils' getty ([fork](https://github.com/jD91mZM2/userutils))
 - orbterm ([fork](https://github.com/jD91mZM2/orbterm))

I am ready to send pull requests that fixes both of the above.